### PR TITLE
multiple improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.json
+

--- a/index.js
+++ b/index.js
@@ -2,55 +2,150 @@ var mqtt = require('mqtt');
 
 homeduino = require('homeduino')
 Board = homeduino.Board
-board = new Board("serialport", {serialDevice:'/dev/ttyAMA0', baudrate: 115200})
+board = new Board("serialport", {serialDevice:'/dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1.0-port0', baudrate: 115200})
+var boardReady = false
 
 var client  = mqtt.connect('mqtt://localhost:1883');
 
+var baseTopic = "homeduino"
+var homeduinoTimout = 5000
+var hasDHT11 = false
+var receivePin = 1
+var sendPin = 11
+var defaultRepeats = 7
+
+function topicToProtocol (topic) {
+  var topicIdx = 2
+  var protocol = topic.split("/")[topicIdx++]
+
+  var options = {}
+
+  if (topic.split("/")[topicIdx] === "channel") {
+    ++topicIdx
+    options.channel = topic.split("/")[topicIdx++]
+  }
+
+  if (topic.split("/")[topicIdx] === "id") {
+    ++topicIdx
+    options.id = topic.split("/")[topicIdx++]
+  }
+
+  if (topic.split("/")[topicIdx] === "unit") {
+    ++topicIdx
+    options.unit = topic.split("/")[topicIdx++]
+  }
+
+  return {protocol: protocol, options: options}
+}
+
+function protocolToTopic (protocol, options)
+{
+  topic = baseTopic + "/rx/" + protocol
+
+  if (options.channel != undefined) {
+    topic += "/channel/" + options.channel
+  }
+  if (options.id != undefined) {
+    topic += "/id/" + options.id
+  }
+  if (options.unit != undefined) {
+    topic += "/unit/" + options.unit
+  }
+
+  return topic
+}
+
 client.on('connect', function () {
-  client.subscribe('input/#');
+  client.subscribe(baseTopic + '/#');
 });
 
 board.on("rfReceive", function(event){
-  console.log ('received:', event.pulseLengths, event.pulses)
+  //console.log ('received:', event.pulseLengths, event.pulses)
 })
 
 board.on("rf", function(event){
-  var topic = event.protocol + "/" + event.values.id;
-  console.log(event)
-  if (event.values.state != undefined){
-        console.log(topic + " - " + event.values.state.toString())
-        client.publish(topic, event.values.state.toString());
-  }
+
+  try {
+    //console.log(event)
+
+    var topic = protocolToTopic(event.protocol, event.values);
+    var payload = ""
+
+    if (event.values.state != undefined) {
+      payload = "{\"state\":" + event.values.state + "}"
+    }
+
+    if (event.values.command != undefined) {
+      payload = "{\"command\":" + event.values.command + "}"
+    }
+
+    if (event.values.contact != undefined) {
+      payload = "\"contact\":" + event.values.contact + "}"
+    }
+
+    //console.log(topic + " - " + payload)
+    client.publish(topic, payload);
+  } catch (e) { console.log(e)};
 })
 
-board.connect().then( function() {
+board.connect(homeduinoTimout).then( function() {
   console.log ("board ready")
-  board.rfControlStartReceiving(0).then( function(){
-    console.log ("receiving...")
-    tempInterval = setInterval(function() {
-      try {
-      board.readDHT(11, 13).then( function(ret) {
-        client.publish("/dht11/temperature", ret.temperature.toString());
-        client.publish("/dht11/humidity", ret.humidity.toString());
-      }
+  boardReady = true
 
-      )
-    } catch (e) {};
-    }, 5000);
+  board.rfControlStartReceiving(receivePin).then( function(){
+    console.log ("receiving...")
+    if (hasDHT11) {
+      tempInterval = setInterval(function() {
+        try {
+          board.readDHT(11, 13).then( function(ret) {
+            client.publish("/dht11/temperature", ret.temperature.toString());
+            client.publish("/dht11/humidity", ret.humidity.toString());
+          })
+        } catch (e) {};
+      }, 5000);    
+    }
   }).done()
 }).done()
 
 
 client.on('message', function (topic, message) {
-  // message is Buffer
-  console.log(topic)
-  var options = {'state': (message.toString().trim() === "true")}
-  var protocol = topic.split("/")[1]
-  options.id = topic.split("/")[2]
-  options.unit = topic.split("/")[3]
+  try {
+    // message is Buffer
+    //console.log("topic: " + topic)
+    //console.log("message: " + message)
 
-  console.log(options)
-  board.rfControlSendMessage(4,3,protocol,options)
-  console.log(message.toString());
+    if (!topic.startsWith(baseTopic + "/tx/") || topic.endsWith("/state") || !boardReady) 
+    {
+      //console.log("ignoring")
+      return
+    }
+
+    payloadJson = JSON.parse(message)
+    rfRepeats = defaultRepeats
+    
+    var protocolOptions = topicToProtocol(topic)
+
+    if (payloadJson["state"] != undefined) {
+      protocolOptions.options.state = payloadJson["state"]
+    }
+
+    if (payloadJson["command"] != undefined) {
+      protocolOptions.options.command = payloadJson["command"]
+    }
+
+    if (payloadJson["rfRepeats"] != undefined) {
+      rfRepeats = payloadJson["rfRepeats"]
+    }
+
+    //console.log("protocol: " + protocolOptions.protocol)
+    //console.log(protocolOptions.options)
+    //console.log("rfRepeats:" + rfRepeats)
+    board.rfControlSendMessage(sendPin, rfRepeats, protocolOptions.protocol, protocolOptions.options).then( function() {
+      statTopic = topic + "/state"
+
+      //console.log("sending stat for " + statTopic)
+      client.publish(statTopic, message, {retain: true})
+    });
+  } catch (e) { console.log(e)};
 });
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ Board = homeduino.Board
 board = new Board("serialport", {serialDevice:'/dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1.0-port0', baudrate: 115200})
 var boardReady = false
 
-var client  = mqtt.connect('mqtt://localhost:1883');
+
+config_json = require("./config.json")
+
+var client  = mqtt.connect('mqtt://localhost:1883', {username:config_json.user, password:config_json.pass});
 
 var baseTopic = "homeduino"
 var homeduinoTimout = 5000


### PR DESCRIPTION
- allow more types of devices, with different parameters such as channel, id
- allow different messages (state, command, ...) for different devices
- allow sending repeat count in the mqtt message
- send a state mqtt message after the radio sends messages
- improve received message format
- customize some options such as pins and timouts

Examples:

```
	- platform: mqtt
	  name: desk_power
	  command_topic: "homeduino/tx/switch26/channel/B/unit/1"
	  state_topic:   "homeduino/tx/switch26/channel/B/unit/1/state"
	  payload_on:  '{"state":true}'
	  payload_off: '{"state":false, "rfRepeats": 15}'

	- platform: mqtt
	  name: leds
	  command_topic: "homeduino/tx/switch28/id/1131696/unit/26223"
	  state_topic:   "homeduino/tx/switch28/id/1131696/unit/26223/state"
	  payload_on:  '{"command": "on"}'
	  payload_off: '{"command": "off"}'
```