### PR TITLE
Fix config handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ homeduino = require('homeduino')
 
 nconf.argv()
   .env()
-  .file({ file: '/etc/433mqtt.json' })
-  .file({ file: './config.default.json'});
+  .file('user', '/etc/433mqtt.json')
+  .file('default', './config.default.json');
 
 Board = homeduino.Board
 board = new Board("serialport", {serialDevice: nconf.get('port'), baudrate:  nconf.get('baud')})


### PR DESCRIPTION
The default config always wins, because the custom key per file was missing. See nconf documentation for file store.