### PR TITLE
Fix topicToProtocol to allow combined usage of unit and id

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,24 +24,47 @@ var defaultRepeats = nconf.get('rf:repeats')
 
 // input/switch15/124333/0
 function topicToProtocol (topic) {
-  var topicIdx = 1
-  var protocol = topic.split("/")[0]
+  var topicIdx = 0
+  var protocol = topic.split("/")[topicIdx]
 
   var options = {}
 
-  if (topic.split("/")[2] === "channel") {
-    options.channel = topic.split("/")[3]
-  }
-  else if (topic.split("/")[1] === "id") {
-    options.id = topic.split("/")[2]
+  topicIdx++; // go to next field
+
+  if (topic.split("/")[topicIdx] === "id") {
+    // found an "id" string, next part between slashes is the actual id
+    topicIdx++; // go to next field
+    options.id = topic.split("/")[topicIdx]
   } else {
-    options.id = topic.split("/")[1]
+    // it was not an "id" string, the field itself is the id
+    options.id = topic.split("/")[topicIdx]
   }
 
-  if (topic.split("/")[topicIdx] === "unit") {
-    ++topicIdx
-    options.unit = topic.split("/")[topicIdx++]
+  topicIdx++; // go to next field
+
+  if (topic.split("/")[topicIdx] === "channel") {
+    // found a "channel" string, next part between slashes is the actual channel
+    topicIdx++; // go to next field
+    options.channel = topic.split("/")[topicIdx]
+  } else {
+    // it was not a "channel" string, the field itself is the unit, not the channel!
+    options.unit = topic.split("/")[topicIdx]
   }
+
+  topicIdx++; // go to next field
+
+  // check if we have tokens left to parse
+  if (topicIdx < topic.split("/").length) {
+    if (topic.split("/")[topicIdx] === "unit") {
+      // found a "unit" string, next part between slashes is the actual unit
+      topicIdx++; // go to next field
+      options.unit = topic.split("/")[topicIdx]
+    } else {
+      // it was not a "unit" string, the field itself is the unit
+      options.unit = topic.split("/")[topicIdx]
+    }
+  }
+
   return {protocol: protocol, options: options}
 }
 


### PR DESCRIPTION
I have devices that use the `switch1` protocol. I have all my devices under the same `id` and have to address them via the `unit` parameter.

The current implementation of `topicToProtocol` does not allow to use an `id` in combination with a `unit`.

The parsing code expects the topic to be `input/switch1/id/1234/channel/4321` or `input/switch1/1234/4321`. However, the `4321` won't be parsed in the second example and only the `id` is set.

The part of the code that parses the `unit` expects it to be in the same position as the `id`. If I send a message to `input/switch1/unit/1` I end up with the `id` to be the string `"unit"` and the `unit` to be correctly set to `1`.

I changed the parsing code to allow the combined usage of all three parameters `id`, `channel`, and `unit`.

The example comment `input/switch15/124333/0` has no annotations, so I guess the last zero should be the unit (not the channel). My code interprets that as `id` 124333 and `unit` 0. If this is wrong, I can change the PR accordingly.

I tried not to break the current API. There are cases where the user can supply completely wrong topics and they will parse with unexpected results, but for correctly set topics my parsing code should work.